### PR TITLE
Fix Grandpa fishing game to keep rod-in-water state when key or button is pressed

### DIFF
--- a/games/grandpa-fishing-battle/js/game.js
+++ b/games/grandpa-fishing-battle/js/game.js
@@ -145,12 +145,6 @@ function handlePlayerInput(player, action) {
       if ((player === 1 && player2State === 'rod-in-water') || (player === 2 && player1State === 'rod-in-water')) {
         matchStarted = true;
       }
-    } else if (playerState === 'rod-in-water') {
-      playerState = 'pulling-rod-out';
-      playerAnticipation = anticipationFrames;
-    } else if (playerState === 'pulling-rod-out') {
-      playerState = 'idle';
-      playerSprite.setTexture(playerIdleTexture);
     }
   } else if (action === 'pointerup' || action === 'keyup') {
     if (playerState === 'pulling-rod-out' && playerAnticipation > 0) {


### PR DESCRIPTION


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Feod/PhaserJam/pull/27?shareId=dbedeae0-bb0e-474c-a68b-3858339f9080).